### PR TITLE
Fix bug

### DIFF
--- a/git-release
+++ b/git-release
@@ -24,10 +24,12 @@ if [[ $UNCOMMITTED_CHANGES != 0 ]] ; then
     fi
 fi
 
+set +e
 CURRENT_VERSION=`git describe --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' 2> /dev/null`
 if [[ $? != 0 ]] ; then
     CURRENT_VERSION="v0.1.0"
 fi
+set -e
 
 SEMVER_REGEX='^v([1-9][0-9]*|0)\.([1-9][0-9]*|0)\.([1-9][0-9]*|0)$'
 if [[ ! "$CURRENT_VERSION" =~ $SEMVER_REGEX ]] ; then


### PR DESCRIPTION
The bug occurred when no previous semver tag was present, while set -e option was on. That case made the entire script fail, instead of setting CURRENT_VERSION=v0.1.0